### PR TITLE
Fix browser issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,15 @@
         "@types/node": "*"
       }
     },
+    "@types/timing-safe-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/timing-safe-equal/-/timing-safe-equal-1.0.0.tgz",
+      "integrity": "sha512-aj+jsT8WFzf1CBLqDuOE+ymg7LBXS5NtmU0+H0yh9LlriK2sFh1hlzxn531RP/UnbsnydPVYOMC6/bQcWOWZxQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/tmp": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
@@ -2529,6 +2538,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "timing-safe-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/timing-safe-equal/-/timing-safe-equal-1.0.0.tgz",
+      "integrity": "sha1-GaZtwlSwy2uW/x6bHxa5uHRQynM="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pumpify": "^2.0.1",
     "readable-stream": "^3.6.0",
     "stream-to-async-iterator": "^0.2.0",
+    "timing-safe-equal": "^1.0.0",
     "tweetnacl": "^1.0.3",
     "uuid": "^8.3.2"
   },
@@ -44,6 +45,7 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@tsconfig/recommended": "^1.0.1",
     "@types/mocha": "^8.0.3",
+    "@types/timing-safe-equal": "^1.0.0",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",

--- a/src/chunk/chunk.ts
+++ b/src/chunk/chunk.ts
@@ -1,5 +1,8 @@
 import * as Stream from 'readable-stream'
 
+// @ts-ignore
+Buffer.prototype._isBuffer = true;
+
 // Nice references for stream implementations:
 // https://codereview.stackexchange.com/questions/57492/chunkertransformstream-a-transform-stream-to-take-arbitrary-chunk-sizes-and-mak
 // https://github.com/Olegas/node-chunking-streams

--- a/src/header/mac.ts
+++ b/src/header/mac.ts
@@ -87,5 +87,5 @@ export const calculate = (
   ...Uint8Array.from(ephemeralBox.slice(-32)),
  ]))
 
- return hash.slice(0, 32)
+ return Buffer.from(Array.from(hash.slice(0, 32)))
 }

--- a/src/payload/authenticators_list.ts
+++ b/src/payload/authenticators_list.ts
@@ -1,4 +1,5 @@
 import * as Crypto from 'crypto'
+import timingSafeEqual from 'timing-safe-equal'
 import * as MacTag from './mac_tag'
 import * as Sha512 from '../ed25519/sha512'
 import * as FinalFlag from './final_flag'
@@ -98,5 +99,8 @@ export const verify = (
   const signature: Uint8Array = hmac.read()
 
   // Constant time compare.
-  return Crypto.timingSafeEqual(signature.slice(0, 32), authenticator)
+  return timingSafeEqual(
+    Buffer.from(Array.from(signature.slice(0, 32))),
+    Buffer.from(Array.from(authenticator))
+  )
 }


### PR DESCRIPTION
One issue was that `crypto.timing-safe-equal` is not implemented in the browser crypto lib so I needed to add the `timing-safe-equal` npm package.

The other issue was that the Uint8Array being returned from the calculate function in `src/header/mac.ts` was causing issues in the browser but not in the node environment. Not sure why, but converting the Uint8Array to a buffer seems to fix it.